### PR TITLE
expose the last_forwarded_ip/2 function for usage outside of Plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ end
 
 Note that, due to limitations in the [inet_cidr](https://github.com/Cobenian/inet_cidr) library used to parse them, `:proxies` **must** be written in full CIDR notation, even if specifying just a single IP. So instead of `"127.0.0.1"` and `"a:b::c:d"`, you would use `"127.0.0.1/32"` and `"a:b::c:d/128"`.
 
+### Without plug
+
+For usage outside of plug, there is the `RemoteIp.last_forwarded_ip/2` function, which can be used like so:
+
+```elixir
+RemoteIp.last_forwarded_ip([{"x-forwarded-for", "1.2.3.4"}]) => {1, 2, 3, 4}
+```
+
+The headers can also be customized like so:
+
+```elixir
+RemoteIp.last_forwarded_ip([{"x-foo", "1.2.3.4"}],
+  headers: ~w[x-foo x-bar x-baz],
+  proxies: ~w[1.2.0.0/16]
+) => {1, 2, 3, 4}
+
+
 ## Background
 
 ### Problem: Your app is behind a proxy and you want to know the original client's IP address.

--- a/test/remote_ip_test.exs
+++ b/test/remote_ip_test.exs
@@ -24,6 +24,17 @@ defmodule RemoteIpTest do
   #
   @conn %Plug.Conn{remote_ip: :peer}
 
+  describe "last_forwarded_ip/2" do
+    test "using the default options" do
+      assert RemoteIp.last_forwarded_ip([]) == nil
+      assert RemoteIp.last_forwarded_ip([{"x-forwarded-for", "1.2.3.4"}]) == {1, 2, 3, 4}
+    end
+
+    test "using custom headers" do
+      assert RemoteIp.last_forwarded_ip([{"x-custom", "1.2.3.4"}], headers: ["x-custom"]) == {1, 2, 3, 4}
+    end
+  end
+
   test "zero hops (i.e., no forwarding headers)" do
     assert :peer == @conn |> remote_ip
     assert :peer == @conn |> remote_ip(headers: ~w[])


### PR DESCRIPTION
In some circumstances, it is possible to get a subset of headers without the
full conn. An example of this is in Phoenix sockets, where only x_headers can be
fetched.

https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-shared-configuration

In this case, currently using RemoteIP involves doing something like this as
conn is not available:

```elixir
def connect({connect_info: %{x_headers: headers}}) do
  RemoteIp.call(%Plug.Conn{req_headers: headers}, RemoteIp.init()).remote_ip
end
```

With this PR, someone using this library with Phoenix sockets could do:

```elixir
  RemoteIp.last_forwarded_ip(headers)
```