### PR TITLE
Make debug logging optional

### DIFF
--- a/lib/remote_ip.ex
+++ b/lib/remote_ip.ex
@@ -171,9 +171,9 @@ defmodule RemoteIp do
   end
 
   defp last_forwarded_ip(req_headers, config) do
-    Logger.debug(fn -> start(config) end)
+    maybe_log_debug(fn -> start(config) end)
     ip = req_headers |> ips_given(config) |> most_recent_client_given(config)
-    Logger.debug(fn -> stop(ip) end)
+    maybe_log_debug(fn -> stop(ip) end)
     ip
   end
 
@@ -188,15 +188,15 @@ defmodule RemoteIp do
   defp client?(ip, %RemoteIp.Config{clients: clients, proxies: proxies}) do
     cond do
       clients |> contains?(ip) ->
-        Logger.debug(fn -> known_client(ip) end)
+        maybe_log_debug(fn -> known_client(ip) end)
         true
 
       proxies |> contains?(ip) ->
-        Logger.debug(fn -> known_proxy(ip) end)
+        maybe_log_debug(fn -> known_proxy(ip) end)
         false
 
       true ->
-        Logger.debug(fn -> presumably_client(ip) end)
+        maybe_log_debug(fn -> presumably_client(ip) end)
         true
     end
   end
@@ -227,5 +227,9 @@ defmodule RemoteIp do
 
   defp presumably_client(ip) do
     [inspect(__MODULE__), " assumes ", inspect(ip), " is a client IP"]
+  end
+
+  defp maybe_log_debug(any) do
+    if Application.get_env(:remote_ip, :debug), do: Logger.debug(any)
   end
 end

--- a/lib/remote_ip/headers.ex
+++ b/lib/remote_ip/headers.ex
@@ -5,7 +5,7 @@ defmodule RemoteIp.Headers do
 
   require Logger
 
-  @doc  """
+  @doc """
   Selects the appropriate headers and parses IPs out of them.
 
   * `headers` - The entire list of the `Plug.Conn` `req_headers`
@@ -27,15 +27,15 @@ defmodule RemoteIp.Headers do
   @spec parse([header], allowed) :: [ip]
 
   def parse(headers, %MapSet{} = allowed) when is_list(headers) do
-    Logger.debug(fn -> parsing(headers) end)
+    maybe_log_debug(fn -> parsing(headers) end)
     ips = headers |> allow(allowed) |> parse_each
-    Logger.debug(fn -> parsed(ips) end)
+    maybe_log_debug(fn -> parsed(ips) end)
     ips
   end
 
   defp allow(headers, allowed) do
     filtered = Enum.filter(headers, &allow?(&1, allowed))
-    Logger.debug(fn -> considering(filtered) end)
+    maybe_log_debug(fn -> considering(filtered) end)
     filtered
   end
 
@@ -77,5 +77,9 @@ defmodule RemoteIp.Headers do
       " parsed the request headers into the IPs ",
       inspect(ips, pretty: true)
     ]
+  end
+
+  defp maybe_log_debug(any) do
+    if Application.get_env(:remote_ip, :debug), do: Logger.debug(any)
   end
 end


### PR DESCRIPTION
Debug logs are a bit verbose in local development, but they currently can't be disabled without upping the logger level (and losing phoenix debug logs, etc).

This PR allows you to enable it via an application env variable (default false)

```elixir
config :remote_ip, debug: true
```

I'd be more than happy to rework it into a plug option, but it would require passing the `Config` struct into `RemoteIp.Headers` functions, which felt rather dirty.