### PR TITLE
Catch UnicodeConversionError

### DIFF
--- a/lib/remote_ip/headers/generic.ex
+++ b/lib/remote_ip/headers/generic.ex
@@ -43,13 +43,18 @@ defmodule RemoteIp.Headers.Generic do
   defp parse_ips(strings) do
     Enum.reduce(strings, [], fn string, ips ->
       case parse_ip(string) do
-        {:ok, ip}         -> [ip | ips]
-        {:error, :einval} -> ips
+        {:ok, ip}                  -> [ip | ips]
+        {:error, :einval}          -> ips
+        {:error, :invalid_unicode} -> ips
       end
     end) |> Enum.reverse
   end
 
   defp parse_ip(string) do
-    string |> to_charlist |> :inet.parse_strict_address
+    try do
+      string |> to_charlist |> :inet.parse_strict_address
+    rescue
+      UnicodeConversionError -> {:error, :invalid_unicode}
+    end
   end
 end

--- a/test/remote_ip/headers/generic_test.exs
+++ b/test/remote_ip/headers/generic_test.exs
@@ -10,6 +10,7 @@ defmodule RemoteIp.Headers.GenericTest do
       assert [] == Generic.parse("      ")
       assert [] == Generic.parse("not_an_ip")
       assert [] == Generic.parse("unknown")
+      assert [] == Generic.parse(<<240, 253, 253, 253>>)
     end
 
     test "bad IPv4" do


### PR DESCRIPTION
I discovered a bug in production, when invalid unicode is passed as a header string. This PR traps this case, and prevents it from throwing an exception.