### PR TITLE
Add support of Logger.metadata

### DIFF
--- a/lib/remote_ip.ex
+++ b/lib/remote_ip.ex
@@ -123,8 +123,14 @@ defmodule RemoteIp do
   def call(conn, %RemoteIp.Config{} = config) do
     case last_forwarded_ip(conn.req_headers, config) do
       nil -> conn
-      ip  -> %{conn | remote_ip: ip}
+      ip  ->
+        Logger.metadata(remote_ip: convert_to_string(ip))
+        %{conn | remote_ip: ip}
     end
+  end
+
+  defp convert_to_string(ip) do
+    ip |> :inet_parse.ntoa() |> to_string()
   end
 
   @doc """


### PR DESCRIPTION
`Plug.RequestId` supports print request_id to console with following
setting:

    config :logger, :console, metadata: [:request_id]

Reference:
https://github.com/elixir-plug/plug/blob/3193ab3a8e1973e2fcc37b33417724a45dac857c/lib/plug/request_id.ex#L11

It would be nice if remote_ip support this feature, too:

    config :logger, :console, metadata: [:request_id, :remote_ip]

So, here is it. ;)